### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/ch10/top-talkers/main.go
+++ b/ch10/top-talkers/main.go
@@ -150,7 +150,7 @@ func main() {
 		log.Fatal(err)
 	}
 	hostname := listenAddrUrl.Hostname()
-	port, err := strconv.ParseUint(listenAddrUrl.Port(), 10, 64)
+	port, err := strconv.ParseUint(listenAddrUrl.Port(), 10, 16)
 	if err != nil {
 		log.Errorf("Port %s could not be converted to integer", listenAddrUrl.Port())
 		return


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/10](https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/10)

Use a parse size that matches the target domain for ports, and validate before converting to `int`.  
Best fix here: parse directly as 16-bit unsigned (`ParseUint(..., 10, 16)`) since TCP/UDP/SFlow ports are in `0..65535`. Then convert to `int` only after successful parse. This preserves behavior for valid ports and prevents oversized values from ever being accepted.

In `ch10/top-talkers/main.go`, change line 153 from 64-bit parsing to 16-bit parsing:
- `strconv.ParseUint(listenAddrUrl.Port(), 10, 64)` → `strconv.ParseUint(listenAddrUrl.Port(), 10, 16)`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
