### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,6 +12,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab    
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: builder


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/14](https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/14)

Add an explicit `permissions` block at the workflow root (applies to all jobs) with only the scopes needed:

- `contents: read` (needed for checkout/metadata reading repo content)
- `packages: write` (needed to push to GitHub Container Registry)

This is the minimal, functionality-preserving fix for this file.  
Edit **`.github/workflows/builder.yml`** by inserting the `permissions` section between the trigger section (`on:` … `workflow_dispatch:`) and `env:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
