### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/packt-builder.yml
+++ b/.github/workflows/packt-builder.yml
@@ -12,6 +12,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab    
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/builder


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/13](https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/13)

Add an explicit `permissions` block at the workflow root (applies to all jobs) with only the scopes this workflow needs:

- `contents: read` (for checkout/metadata based on repository content)
- `packages: write` (required to push images to GitHub Container Registry)

This preserves existing behavior (build + push still works) while enforcing least privilege and eliminating dependency on external default settings.

Edit `.github/workflows/packt-builder.yml` by inserting the `permissions` section between the trigger section and `env:` (or equivalently before `jobs:`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
