### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -12,6 +12,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab    
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/host


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/12](https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/12)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged but still sufficient for current behavior.

Best fix here (without changing functionality):
- Add workflow-level permissions near the top-level keys (after `on`/before `env` is fine):
  - `contents: read` (needed for checkout and repo read operations)
  - `packages: write` (needed to push images to GHCR)
- Keep job logic unchanged.

File to edit:
- `.github/workflows/host.yml`  
Add the new `permissions` block at root level so it applies to the `docker` job.

No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
