### PR TITLE
Potential fix for code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/ch04/http/server/main.go
+++ b/ch04/http/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"net"
 	"net/http"
@@ -75,7 +76,7 @@ func lookup(w http.ResponseWriter, req *http.Request) {
 		}
 
 	}
-	fmt.Fprint(w, response)
+	fmt.Fprint(w, html.EscapeString(response))
 }
 
 func check(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/1](https://github.com/ibiscum/Network-Automation-with-Go/security/code-scanning/1)

To fix this safely without changing behavior, escape response content before writing it to the client in the `lookup` handler. For HTML contexts in Go, use `html.EscapeString`. This is the minimal and best change here: preserve existing response text semantics while neutralizing injected HTML/JS.

In `ch04/http/server/main.go`:
- Add import for Go standard library package `html`.
- In `lookup`, replace `fmt.Fprint(w, response)` with `fmt.Fprint(w, html.EscapeString(response))`.

This ensures any tainted content (including reflected query values) is output-encoded before reaching the sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
